### PR TITLE
refactor: fix compatibility with k8s 1.24

### DIFF
--- a/applier/direct.go
+++ b/applier/direct.go
@@ -85,7 +85,7 @@ func newOptions(flags *apply.ApplyFlags, namespace string) (*apply.ApplyOptions,
 	}
 
 	// allow for a success message operation to be specified at print time
-	dryRunVerifier := resource.NewDryRunVerifier(dynamicClient, flags.Factory.OpenAPIGetter())
+	dryRunVerifier := resource.NewQueryParamVerifier(dynamicClient, flags.Factory.OpenAPIGetter(), resource.QueryParamDryRun)
 	toPrinter := func(operation string) (printers.ResourcePrinter, error) {
 		flags.PrintFlags.NamePrintFlags.Operation = operation
 		cmdutil.PrintFlagsWithDryRunStrategy(flags.PrintFlags, cmdutil.DryRunNone)

--- a/syncer/testing/testing.go
+++ b/syncer/testing/testing.go
@@ -160,7 +160,6 @@ func stripObject(obj runtime.Object) runtime.Object {
 		panic(err)
 	}
 
-	accessor.SetClusterName("")
 	accessor.SetResourceVersion("")
 	accessor.SetOwnerReferences(nil)
 	accessor.SetGeneration(0)

--- a/syncer/translator/namespaced_translator.go
+++ b/syncer/translator/namespaced_translator.go
@@ -290,6 +290,5 @@ func ResetObjectMetadata(obj metav1.Object) {
 	obj.SetDeletionGracePeriodSeconds(nil)
 	obj.SetOwnerReferences(nil)
 	obj.SetFinalizers(nil)
-	obj.SetClusterName("")
 	obj.SetManagedFields(nil)
 }


### PR DESCRIPTION
It looks to be that these recent changes on k8s side:
* https://github.com/kubernetes/cli-runtime/commit/009217a3bd692d6625e79ed973cec2a553907ea2
* https://github.com/kubernetes/apimachinery/commit/5556187efba9d67964da862d472965aa84506e79

requires this kind of small change to vcluster-sdk.