### PR TITLE
chore: bump vcluster chart version in the examples

### DIFF
--- a/examples/bootstrap-with-deployment/devspace.yaml
+++ b/examples/bootstrap-with-deployment/devspace.yaml
@@ -26,7 +26,7 @@ deployments:
       chart:
         name: vcluster
         repo: https://charts.loft.sh
-        version: 0.10.0
+        version: 0.11.1
       values:
         plugin:
           bootstrap-with-deployment:

--- a/examples/crd-sync/devspace.yaml
+++ b/examples/crd-sync/devspace.yaml
@@ -29,7 +29,7 @@ deployments:
       chart:
         name: vcluster
         repo: https://charts.loft.sh
-        version: 0.10.0
+        version: 0.11.1
       valuesFiles:
         - plugin.yaml
       values:

--- a/examples/hooks/devspace.yaml
+++ b/examples/hooks/devspace.yaml
@@ -17,7 +17,7 @@ deployments:
       chart:
         name: vcluster
         repo: https://charts.loft.sh
-        version: 0.10.0
+        version: 0.11.1
       valuesFiles:
         - plugin.yaml
       values:

--- a/examples/pull-secret-sync/devspace.yaml
+++ b/examples/pull-secret-sync/devspace.yaml
@@ -26,7 +26,7 @@ deployments:
       chart:
         name: vcluster
         repo: https://charts.loft.sh
-        version: 0.10.0
+        version: 0.11.1
       valuesFiles:
         - plugin.yaml
       values:


### PR DESCRIPTION
This is done mainly to fix the missing `VCLUSTER_PLUGIN_NAME` env var.