### PR TITLE
enchancment: set ownerReference on synced resources in accordance to vcluster behavior

### DIFF
--- a/translate/translate.go
+++ b/translate/translate.go
@@ -51,12 +51,12 @@ func IsManaged(obj runtime.Object) bool {
 }
 
 func GetOwnerReference() []metav1.OwnerReference {
-	if Owner == nil {
+	if Owner == nil || Owner.GetName() == "" || Owner.GetUID() == "" {
 		return nil
 	}
 
 	typeAccessor, err := meta.TypeAccessor(Owner)
-	if err != nil {
+	if err != nil || typeAccessor.GetAPIVersion() == "" || typeAccessor.GetKind() == "" {
 		return nil
 	}
 

--- a/translate/util/util.go
+++ b/translate/util/util.go
@@ -1,0 +1,33 @@
+package util
+
+import (
+	"github.com/loft-sh/vcluster-sdk/syncer/context"
+	"github.com/loft-sh/vcluster-sdk/translate"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog"
+)
+
+// FindOwner finds the owner of the synced resources and sets it, unless SetOwner is set to false
+func FindOwner(ctx *context.RegisterContext) error {
+	if ctx.CurrentNamespace != ctx.Options.TargetNamespace {
+		if ctx.Options.SetOwner {
+			klog.Warningf("Skip setting owner, because current namespace %s != target namespace %s", ctx.CurrentNamespace, ctx.Options.TargetNamespace)
+		}
+		return nil
+	}
+
+	if ctx.Options.SetOwner {
+		service := &corev1.Service{}
+		err := ctx.CurrentNamespaceClient.Get(ctx.Context, types.NamespacedName{Namespace: ctx.CurrentNamespace, Name: ctx.Options.ServiceName}, service)
+		if err != nil {
+			return errors.Wrap(err, "get vcluster service")
+		}
+
+		translate.Owner = service
+		return nil
+	}
+
+	return nil
+}


### PR DESCRIPTION
https://github.com/loft-sh/vcluster-generic-crd-sync-plugin/issues/28