### PR TITLE
fix: improve handling of old host CRDs

### DIFF
--- a/translate/crd.go
+++ b/translate/crd.go
@@ -3,14 +3,15 @@ package translate
 import (
 	"context"
 	"fmt"
+	"math"
+	"time"
+
 	"github.com/pkg/errors"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1clientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"math"
-	"time"
 
 	"github.com/loft-sh/vcluster-sdk/applier"
 	"github.com/loft-sh/vcluster-sdk/log"
@@ -52,6 +53,7 @@ func EnsureCRDFromPhysicalCluster(ctx context.Context, pConfig *rest.Config, vCo
 	crdDefinition.ResourceVersion = ""
 	crdDefinition.ManagedFields = nil
 	crdDefinition.OwnerReferences = nil
+	crdDefinition.Spec.PreserveUnknownFields = false
 	crdDefinition.Status = apiextensionsv1.CustomResourceDefinitionStatus{}
 	vClient, err := apiextensionsv1clientset.NewForConfig(vConfig)
 	if err != nil {


### PR DESCRIPTION
Always set `.Spec.PreserveUnknownFields = false` because that is needed for compatibility with `apiextensions.k8s.io/v1`, as mentioned in the docs - https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#field-pruning

**Release note:**
The `spec.preserveUnknownFields` field of CRDs copied from the host cluster will always be set to `false` 

This fixes the problem reported by the user here - https://loft-sh.slack.com/archives/C01N273CF4P/p1669781095611459
