### PR TITLE
added startAsync

### DIFF
--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -209,6 +209,15 @@ func (m *manager) Start() error {
 	return nil
 }
 
+func (m *manager) StartAsync() (<-chan struct{}, error) {
+	err := m.start()
+	if err != nil {
+		return nil, err
+	}
+
+	return m.context.Context.Done(), nil
+}
+
 func (m *manager) startInterceptors() error {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		handlerName := r.Header.Get("VCluster-Plugin-Handler-Name")

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -56,6 +56,10 @@ func Start() error {
 	return defaultManager.Start()
 }
 
+func StartAsync() (<-chan struct{}, error) {
+	return defaultManager.StartAsync()
+}
+
 func UnmarshalConfig(into interface{}) error {
 	return defaultManager.UnmarshalConfig(into)
 }

--- a/plugin/types.go
+++ b/plugin/types.go
@@ -37,9 +37,10 @@ type Manager interface {
 	// will stop if the pod will lose leader election.
 	Start() error
 
-	// Start runs all the registered syncers and will block. It only executes
-	// the functionality if the current vcluster pod is the current leader and
-	// will stop if the pod will lose leader election.
+	// Start runs all the registered syncers and will not block. It only executes
+	// the functionality if the current vcluster pod is the current leader
+	// You need to exit the plugin when the channel is closed since that means you lost
+	// leader election
 	StartAsync() (<-chan struct{}, error)
 
 	// UnmarshalConfig retrieves the plugin config from environment and parses it into

--- a/plugin/types.go
+++ b/plugin/types.go
@@ -37,6 +37,11 @@ type Manager interface {
 	// will stop if the pod will lose leader election.
 	Start() error
 
+	// Start runs all the registered syncers and will block. It only executes
+	// the functionality if the current vcluster pod is the current leader and
+	// will stop if the pod will lose leader election.
+	StartAsync() (<-chan struct{}, error)
+
 	// UnmarshalConfig retrieves the plugin config from environment and parses it into
 	// the given object.
 	UnmarshalConfig(into interface{}) error


### PR DESCRIPTION
part of eng-3892 

need to be able to register some controllers after we are leader, so created startAsync to be able to use a start function without waiting for the context to be done 