### PR TITLE
ci: add renovate config

### DIFF
--- a/.github/workflows/validate-renovate.yaml
+++ b/.github/workflows/validate-renovate.yaml
@@ -1,0 +1,18 @@
+name: Validate Renovate Config
+
+on:
+  pull_request:
+    paths:
+      - 'renovate.json'
+      - 'renovate.json5'
+      - '.renovaterc'
+      - '.renovaterc.json'
+
+permissions: {}
+
+jobs:
+  validate-renovate:
+    permissions:
+      contents: read
+      pull-requests: read
+    uses: loft-sh/github-actions/.github/workflows/validate-renovate.yaml@b52efbd927586ea78282073f79d2423e552c9f62 # validate-renovate/v1

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":semanticCommits",
+    "helpers:pinGitHubActionDigests"
+  ],
+  "baseBranchPatterns": ["main"],
+  "labels": ["dependencies"],
+  "prHourlyLimit": 5,
+  "prConcurrentLimit": 10,
+  "minimumReleaseAge": "3 days",
+  "schedule": ["before 6am on monday"],
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["security"]
+  },
+  "postUpdateOptions": ["gomodTidy"],
+  "ignorePaths": [
+    "**/node_modules/**",
+    "vendor/**",
+    "examples/**"
+  ],
+  "packageRules": [
+    {
+      "description": "Group GitHub Actions updates",
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions"
+    },
+    {
+      "description": "Group Go patch updates",
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["patch"],
+      "groupName": "go-patch-updates"
+    },
+    {
+      "description": "Kubernetes Go modules move in lockstep",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["k8s.io/{/,}**", "sigs.k8s.io/{/,}**"],
+      "groupName": "k8s-go-deps"
+    },
+    {
+      "description": "Group loft-sh Go modules",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["github.com/loft-sh/{/,}**"],
+      "groupName": "loft-sh-go-deps"
+    },
+    {
+      "description": "vCluster bumps update go.mod and the e2e workflow pins together (mirrors hack/bump-vcluster-dep.go)",
+      "matchPackageNames": [
+        "github.com/loft-sh/vcluster",
+        "loft-sh/vcluster",
+        "ghcr.io/loft-sh/vcluster-pro"
+      ],
+      "groupName": "vcluster"
+    },
+    {
+      "description": "kind CLI and kindest/node image versions must match",
+      "matchPackageNames": ["kubernetes-sigs/kind", "kindest/node"],
+      "groupName": "kind"
+    },
+    {
+      "description": "Group the go directive with the golang build image",
+      "matchPackageNames": ["go", "golang"],
+      "groupName": "golang-version"
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "vCluster CLI version in the e2e workflow env",
+      "managerFilePatterns": ["/^\\.github/workflows/e2e\\.yaml$/"],
+      "matchStrings": ["\\n  VCLUSTER_VERSION: (?<currentValue>v[\\d.]+)"],
+      "depNameTemplate": "loft-sh/vcluster",
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "description": "vCluster Pro background proxy image in the e2e workflow env",
+      "managerFilePatterns": ["/^\\.github/workflows/e2e\\.yaml$/"],
+      "matchStrings": ["\\n  VCLUSTER_BACKGROUND_PROXY_IMAGE: ghcr\\.io/loft-sh/vcluster-pro:(?<currentValue>[\\d.]+)"],
+      "depNameTemplate": "ghcr.io/loft-sh/vcluster-pro",
+      "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "description": "kind version passed to engineerd/setup-kind in the e2e workflow",
+      "managerFilePatterns": ["/^\\.github/workflows/e2e\\.yaml$/"],
+      "matchStrings": ["uses: engineerd/setup-kind@\\S+\\s+with:\\s+version: \"(?<currentValue>v[\\d.]+)\""],
+      "depNameTemplate": "kubernetes-sigs/kind",
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "description": "kindest/node image for the e2e kind cluster",
+      "managerFilePatterns": ["/^\\.github/workflows/e2e\\.yaml$/"],
+      "matchStrings": ["image: (?<depName>kindest/node):(?<currentValue>v[\\d.]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?"],
+      "datasourceTemplate": "docker"
+    }
+  ]
+}


### PR DESCRIPTION
Closes DEVOPS-964

## Summary

- Add `renovate.json` from the org baseline: weekly schedule (security alerts bypass it), semantic commits, digest-pinned GitHub Actions, grouped updates, `dependencies` label, 3-day release stabilization
- Add custom regex managers for the version pins in `.github/workflows/e2e.yaml` and group them with the `go.mod` dep so a vCluster bump arrives as one PR (mirrors `hack/bump-vcluster-dep.go`)
- Add the `validate-renovate` caller workflow (pinned to the `validate-renovate/v1` SHA) so config edits are validated on every PR

## What is covered

| Surface | Manager |
|---|---|
| `go.mod` (258 deps) + `vendor/` | `gomod` with `gomodTidy`; re-vendoring is automatic (`vendor/modules.txt` present) |
| `uses:` in 3 workflows (14 actions) | `github-actions` + digest pinning |
| `golang` image in `e2e/test_plugin/Dockerfile` | `dockerfile`, grouped with the `go` directive as `golang-version` |
| `VCLUSTER_VERSION` in e2e.yaml | custom regex → github-releases, grouped as `vcluster` |
| `VCLUSTER_BACKGROUND_PROXY_IMAGE` in e2e.yaml | custom regex → docker, grouped as `vcluster` |
| kind version (`engineerd/setup-kind` input) | custom regex → github-releases, grouped as `kind` |
| `kindest/node` image + digest | custom regex → docker, grouped as `kind` |

Grouping: `go-patch-updates`, `k8s-go-deps` (k8s.io/sigs.k8s.io lockstep), `loft-sh-go-deps`, `vcluster` (go.mod + both e2e env pins together), `kind` (CLI and node image must match), `golang-version`, `github-actions`.

## Deliberately not managed

- `examples/**` — the example go.mods pin `github.com/loft-sh/vcluster-sdk` itself at a pseudo-version and are refreshed in lockstep by the existing "chore: update examples to vCluster vX.Y.Z" flow; Renovate updating them independently would conflict with that
- `vendor/**` — vendored copies, never updated directly
- plugin.yaml images (`ghcr.io/loft-sh/vcluster-example-*`, `test-plugin:v1`) — release artifacts of this repo / locally built in CI
- `k8s.gcr.io/pause:3.2` in the e2e test manifest — test fixture
- `FROM alpine` (untagged) in `e2e/test_plugin/Dockerfile` — no version to track

## Test plan

- [x] `renovate-config-validator` passes
- [x] All 4 custom-manager regexes verified to match exactly once against `.github/workflows/e2e.yaml` with correct captured values (incl. the `kindest/node` digest)
- [x] Local `--dry-run=extract` with the committed config: `dockerfile` 1 file/2 deps, `github-actions` 3 files/14 deps, `gomod` 1 file/258 deps, `regex` 4/4 — examples and vendor excluded as intended
- [x] `actionlint` and `zizmor` clean on the new workflow
- [ ] `validate-renovate` check green on this PR (triggers because the PR touches `renovate.json`)

## Post-merge checklist

- [ ] Dependency Dashboard issue appears and the first run resolves all managers
- [ ] Existing GitHub security alerts (70 on main per push output) start getting `security`-labeled PRs — these bypass the weekly schedule, expect a burst
- [ ] `RENOVATE_GITHUB_TOKEN` not expected to be needed (all datasources public) — confirm the first run has no host errors